### PR TITLE
Initialize minimal project skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-# KGP-assisstant
+# KGP Assistant
+
+A smart assistant for IIT Kharagpur students. It combines a tiny Retrieval-Augmented Generation (RAG) pipeline, a REST API and a simple Streamlit UI. The goal is to keep the project minimal and fully open source.
+
+## Project Structure
+
+- `agent/` – RAG components and assistant logic
+- `api/` – FastAPI routes
+- `frontend/` – Streamlit interface
+- `kgp_assistant/` – command line entry point
+- `utils/` – small helpers
+- `tests/` – basic test coverage
+
+## Getting Started
+
+```bash
+# install dependencies
+pip install -r requirements.txt
+
+# run the assistant in the terminal
+python kgp_assistant/main.py
+```
+
+To start the API server:
+
+```bash
+python api/server.py
+```
+
+Run the Streamlit demo:
+
+```bash
+streamlit run frontend/app.py
+```
+
+## Testing
+
+Run the tests with `pytest`:
+
+```bash
+pytest
+```

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,2 @@
+# Init for agent package
+from .agent import KGAssistant

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -1,0 +1,16 @@
+"""Main assistant logic."""
+
+from typing import List
+
+from .rag import SimpleRAG
+
+
+class KGAssistant:
+    """A small assistant that retrieves relevant info."""
+
+    def __init__(self, docs: List[str]):
+        self.rag = SimpleRAG(docs)
+
+    def ask(self, question: str) -> str:
+        """Answer a question by retrieving a document."""
+        return self.rag.query(question)

--- a/agent/rag.py
+++ b/agent/rag.py
@@ -1,0 +1,21 @@
+"""Simple retrieval module using TF-IDF."""
+
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+from typing import List
+
+
+class SimpleRAG:
+    """A very small retrieval system."""
+
+    def __init__(self, docs: List[str]):
+        self.docs = docs
+        self.vec = TfidfVectorizer()
+        self.doc_vecs = self.vec.fit_transform(docs)
+
+    def query(self, text: str) -> str:
+        """Return the most relevant document for the query."""
+        q_vec = self.vec.transform([text])
+        sims = cosine_similarity(q_vec, self.doc_vecs)[0]
+        idx = sims.argmax()
+        return self.docs[idx]

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,1 @@
+# FastAPI app for the assistant

--- a/api/server.py
+++ b/api/server.py
@@ -1,0 +1,33 @@
+"""FastAPI routes."""
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from agent import KGAssistant
+
+app = FastAPI()
+
+# Example documents. In real use, load academic materials here.
+DOCS = [
+    "IIT Kharagpur was established in 1951.",
+    "The institute has two main semesters each year.",
+    "The central library houses thousands of books."
+]
+
+assistant = KGAssistant(DOCS)
+
+
+class Query(BaseModel):
+    text: str
+
+
+@app.post("/ask")
+async def ask(q: Query):
+    """Return an answer from the assistant."""
+    return {"answer": assistant.ask(q.text)}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,0 +1,19 @@
+"""Minimal Streamlit interface."""
+
+import streamlit as st
+
+from agent import KGAssistant
+
+DOCS = [
+    "IIT Kharagpur was established in 1951.",
+    "The institute has two main semesters each year.",
+    "The central library houses thousands of books."
+]
+
+assistant = KGAssistant(DOCS)
+
+st.title("KGP Assistant")
+query = st.text_input("Ask a question")
+if query:
+    answer = assistant.ask(query)
+    st.write(answer)

--- a/kgp_assistant/__init__.py
+++ b/kgp_assistant/__init__.py
@@ -1,0 +1,1 @@
+# Main entry for the package

--- a/kgp_assistant/main.py
+++ b/kgp_assistant/main.py
@@ -1,0 +1,24 @@
+"""Command line interface for the assistant."""
+
+from agent import KGAssistant
+
+DOCS = [
+    "IIT Kharagpur was established in 1951.",
+    "The institute has two main semesters each year.",
+    "The central library houses thousands of books."
+]
+
+
+def main() -> None:
+    """Run a simple CLI loop."""
+    assistant = KGAssistant(DOCS)
+    print("Type 'exit' to quit")
+    while True:
+        question = input("Ask: ")
+        if question.lower() in {"exit", "quit"}:
+            break
+        print(assistant.ask(question))
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+streamlit
+scikit-learn
+pytest

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,7 @@
+from agent.rag import SimpleRAG
+
+
+def test_retrieve():
+    docs = ["sky is blue", "grass is green"]
+    rag = SimpleRAG(docs)
+    assert rag.query("color of grass") == "grass is green"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+
+from api.server import app
+
+
+client = TestClient(app)
+
+
+def test_ask():
+    resp = client.post("/ask", json={"text": "when was iit kgp established"})
+    assert resp.status_code == 200
+    assert "answer" in resp.json()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+# Utility package

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,0 +1,4 @@
+"""Project constants."""
+
+# Example constant for demonstration
+APP_NAME = "KGP Assistant"

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,0 +1,6 @@
+"""Logging configuration."""
+
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("kgp_assistant")


### PR DESCRIPTION
## Summary
- implement a minimal open-source KGP assistant skeleton
- add simple RAG component and CLI entrypoint
- provide API and Streamlit UI examples
- include basic tests and requirements
- expand README with setup and usage instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684666a80b348321960995e2300f549e